### PR TITLE
Enable Persisting Experiment Definitions To Disk (#42)

### DIFF
--- a/experiments/experiments_test.go
+++ b/experiments/experiments_test.go
@@ -1,0 +1,117 @@
+package experiments
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	parser "github.com/Netflix/p2plab/cue/parser"
+	"github.com/Netflix/p2plab/metadata"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExperimentDefinition(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	db, cleanup := newTestDB(t, "exptestdir")
+	defer func() {
+		require.NoError(t, cleanup())
+	}()
+	var ids []string
+	t.Run("Experiment Creation And Retrieval", func(t *testing.T) {
+		sourceFiles := []string{
+			"../cue/cue.mod/p2plab_example1.cue",
+			"../cue/cue.mod/p2plab_example2.cue",
+		}
+		for _, sourceFile := range sourceFiles {
+			name := strings.Split(sourceFile, "/")
+			exp1 := newTestExperiment(t, sourceFile, name[len(name)-1])
+			ids = append(ids, exp1.ID)
+			exp2, err := db.CreateExperiment(ctx, exp1)
+			require.NoError(t, err)
+			require.Equal(t, exp1.ID, exp2.ID)
+			require.Equal(t, exp1.Status, exp2.Status)
+			require.Equal(t, exp1.Definition, exp2.Definition)
+			exp3, err := db.GetExperiment(ctx, exp1.ID)
+			require.NoError(t, err)
+			require.Equal(t, exp1.ID, exp3.ID)
+			require.Equal(t, exp1.Status, exp3.Status)
+			require.Equal(t, exp1.Definition, exp3.Definition)
+		}
+	})
+	t.Run("List Experiments", func(t *testing.T) {
+		experiments, err := db.ListExperiments(ctx)
+		require.NoError(t, err)
+		for _, experiment := range experiments {
+			if experiment.ID != ids[0] && experiment.ID != ids[1] {
+				t.Error("bad experiment id found")
+			}
+		}
+	})
+	t.Run("Update Experiments", func(t *testing.T) {
+		for _, id := range ids {
+			exp, err := db.GetExperiment(ctx, id)
+			require.NoError(t, err)
+			prevUpdateAt := exp.UpdatedAt
+			exp.Labels = append(exp.Labels, "test label")
+			exp, err = db.UpdateExperiment(ctx, exp)
+			require.NoError(t, err)
+			require.True(t, exp.UpdatedAt.After(prevUpdateAt))
+		}
+	})
+	t.Run("Label Experiments", func(t *testing.T) {
+		exps, err := db.LabelExperiments(
+			ctx,
+			ids,
+			[]string{"should be present"},
+			[]string{"test label"},
+		)
+		require.NoError(t, err)
+		for _, exp := range exps {
+			require.Len(t, exp.Labels, 1)
+			require.Equal(t, exp.Labels[0], "should be present")
+		}
+	})
+	t.Run("Delete Experiment", func(t *testing.T) {
+		require.NoError(t, db.DeleteExperiment(ctx, ids[0]))
+		_, err := db.GetExperiment(ctx, ids[0])
+		require.Error(t, err)
+		_, err = db.GetExperiment(ctx, ids[1])
+		require.NoError(t, err)
+	})
+}
+
+func newTestExperiment(t *testing.T, sourceFile, name string) metadata.Experiment {
+	data, err := ioutil.ReadFile("../cue/cue.mod/p2plab.cue")
+	require.NoError(t, err)
+	sourceData, err := ioutil.ReadFile(sourceFile)
+	require.NoError(t, err)
+	psr := parser.NewParser([]string{string(data)})
+	inst, err := psr.Compile(
+		name,
+		string(sourceData),
+	)
+	require.NoError(t, err)
+	edef, err := inst.ToExperimentDefinition()
+	require.NoError(t, err)
+	return metadata.Experiment{
+		ID:         uuid.New().String(),
+		Status:     metadata.ExperimentRunning,
+		Definition: edef,
+	}
+}
+
+func newTestDB(t *testing.T, path string) (metadata.DB, func() error) {
+	db, err := metadata.NewDB(path)
+	require.NoError(t, err)
+	cleanup := func() error {
+		if err := db.Close(); err != nil {
+			return err
+		}
+		return os.RemoveAll(path)
+	}
+	return db, cleanup
+}

--- a/metadata/db.go
+++ b/metadata/db.go
@@ -16,6 +16,7 @@ package metadata
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -139,6 +140,13 @@ type db struct {
 }
 
 func NewDB(root string) (DB, error) {
+	if _, err := os.Stat(root); os.IsNotExist(err) {
+		if err := os.Mkdir(root, os.FileMode(0775)); err != nil {
+			return nil, err
+		}
+	} else if err != nil {
+		return nil, err
+	}
 	path := filepath.Join(root, "meta.db")
 	boltdb, err := bolt.Open(path, 0644, nil)
 	if err != nil {

--- a/metadata/db_test.go
+++ b/metadata/db_test.go
@@ -1,0 +1,73 @@
+package metadata
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/pkg/errors"
+	bolt "go.etcd.io/bbolt"
+)
+
+func TestDB(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var testDir = "dbmetatest"
+	db, cleanup := newTestDB(t, testDir)
+	defer func() {
+		if err := cleanup(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	var (
+		testBucket = "test"
+		testKey    = "testkey"
+		testValue  = "testvalue"
+	)
+	// this should return an error as we have not populated the datastore
+	if err := db.View(ctx, func(tx *bolt.Tx) error {
+		bkt := tx.Bucket([]byte(testBucket))
+		if bkt == nil {
+			return nil
+		}
+		return errors.New("found bucket")
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Update(ctx, func(tx *bolt.Tx) error {
+		bkt, err := tx.CreateBucket([]byte(testBucket))
+		if err != nil {
+			return err
+		}
+		return bkt.Put([]byte(testKey), []byte(testValue))
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.View(ctx, func(tx *bolt.Tx) error {
+		bkt := tx.Bucket([]byte(testBucket))
+		if bkt == nil {
+			return errors.New("should have found bucket")
+		}
+		data := bkt.Get([]byte(testKey))
+		if data == nil || string(data) != testValue {
+			return errors.New("bad value ofund")
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func newTestDB(t *testing.T, path string) (DB, func() error) {
+	db, err := NewDB(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanup := func() error {
+		if err := db.Close(); err != nil {
+			return err
+		}
+		return os.RemoveAll(path)
+	}
+	return db, cleanup
+}

--- a/metadata/experiment.go
+++ b/metadata/experiment.go
@@ -16,6 +16,7 @@ package metadata
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	"github.com/Netflix/p2plab/errdefs"
@@ -50,6 +51,17 @@ type ExperimentDefinition struct {
 }
 
 type IndependentVariable map[string]interface{}
+
+// ToJSON is a helper function to convert an ExperimentDefinition
+// into it's JSON representation
+func (ed *ExperimentDefinition) ToJSON() ([]byte, error) {
+	return json.Marshal(ed)
+}
+
+// FromJSON loads the experiment definition with the values from data
+func (ed *ExperimentDefinition) FromJSON(data []byte) error {
+	return json.Unmarshal(data, ed)
+}
 
 func (m *db) GetExperiment(ctx context.Context, id string) (Experiment, error) {
 	var experiment Experiment
@@ -228,7 +240,7 @@ func readExperiment(bkt *bolt.Bucket, experiment *Experiment) error {
 		return err
 	}
 
-	experiment.Definition, err = readExperimentDefinition(bkt)
+	experiment.Definition, err = readExperimentDefinition(bkt, experiment)
 	if err != nil {
 		return err
 	}
@@ -254,34 +266,17 @@ func readExperiment(bkt *bolt.Bucket, experiment *Experiment) error {
 	})
 }
 
-func readExperimentDefinition(bkt *bolt.Bucket) (ExperimentDefinition, error) {
+func readExperimentDefinition(bkt *bolt.Bucket, experiment *Experiment) (ExperimentDefinition, error) {
 	var edef ExperimentDefinition
-	/* TODO: enable in a followup PR
 	dbkt := bkt.Bucket(bucketKeyDefinition)
 	if dbkt == nil {
 		return edef, nil
 	}
-
-	cbkt := dbkt.Bucket(bucketKeyCluster)
-	if cbkt != nil {
-		var err error
-		// T
-		// edef.ClusterDefinition, err = readClusterDefinition(cbkt)
-		if err != nil {
-			return edef, nil
-		}
+	edefData := dbkt.Get([]byte(experiment.ID))
+	if edefData == nil {
+		return edef, nil
 	}
-
-	sbkt := dbkt.Bucket(bucketKeyScenario)
-	if sbkt != nil {
-		// var err error
-		edef.ScenarioDefinition, err = readScenarioDefinition(sbkt)
-		if err != nil {
-			return edef, nil
-		}
-	}
-	*/
-	return edef, nil
+	return edef, edef.FromJSON(edefData)
 }
 
 func writeExperiment(bkt *bolt.Bucket, experiment *Experiment) error {
@@ -290,7 +285,7 @@ func writeExperiment(bkt *bolt.Bucket, experiment *Experiment) error {
 		return err
 	}
 
-	err = writeExperimentDefinition(bkt, experiment.Definition)
+	err = writeExperimentDefinition(bkt, experiment)
 	if err != nil {
 		return err
 	}
@@ -313,11 +308,14 @@ func writeExperiment(bkt *bolt.Bucket, experiment *Experiment) error {
 	return nil
 }
 
-func writeExperimentDefinition(bkt *bolt.Bucket, edef ExperimentDefinition) error {
-	// dbkt, err := RecreateBucket(bkt, bucketKeyDefinition)
-	// if err != nil {
-	// 	return err
-	// }
-
-	return nil
+func writeExperimentDefinition(bkt *bolt.Bucket, experiment *Experiment) error {
+	dbkt, err := RecreateBucket(bkt, bucketKeyDefinition)
+	if err != nil {
+		return err
+	}
+	edefData, err := experiment.Definition.ToJSON()
+	if err != nil {
+		return err
+	}
+	return dbkt.Put([]byte(experiment.ID), edefData)
 }


### PR DESCRIPTION
* satisfy go vet, and avoid possible context leak (#40) (#3)

* metadata: enable persisting experiments to disk, add tests

* experiments: add delete test, use reflect for better comparison

* experiments,metadata: implement code review suggestions

* experiments: implement code review changes